### PR TITLE
Convert watcher script into module

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,14 @@
 # solana_whale_watcher
-Monitoring Solana accounts
+
+Utilities for monitoring Solana accounts.
+
+## Usage as a module
+
+The watcher can be run as a module with `python -m app.watcher` or imported in
+your own code:
+
+```python
+from app.watcher import monitor_solana
+
+results = await monitor_solana(max_events=5, threshold_SOL=0.001)
+```

--- a/app/watcher/__init__.py
+++ b/app/watcher/__init__.py
@@ -1,6 +1,4 @@
-import asyncio
 import json
-import pandas as pd
 import websockets
 from solders.rpc.responses import GetTransactionResp
 from solders.transaction_status import UiTransactionStatusMeta
@@ -9,6 +7,8 @@ from solders.pubkey import Pubkey
 from solders.rpc.api import Client
 
 from typing import List, Dict
+
+__all__ = ["extract_sol_changes", "monitor_solana"]
 
 def extract_sol_changes(meta: UiTransactionStatusMeta, account_keys: List[Pubkey]) -> List[Dict]:
     """
@@ -109,8 +109,3 @@ async def monitor_solana(max_events: int = 10, threshold_SOL: float = 0.0) -> Li
 
 
 
-if __name__ == "__main__":
-    results = asyncio.run(monitor_solana(max_events=5, threshold_SOL=0.001))
-    print("FINAL RESULTS:")
-    for r in results:
-        print(r)

--- a/app/watcher/__main__.py
+++ b/app/watcher/__main__.py
@@ -1,0 +1,21 @@
+import argparse
+import asyncio
+from . import monitor_solana
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Monitor Solana transactions")
+    parser.add_argument("--max-events", type=int, default=5, help="number of events to collect")
+    parser.add_argument("--threshold-sol", type=float, default=0.001, help="minimum SOL delta to display")
+    args = parser.parse_args()
+
+    results = asyncio.run(
+        monitor_solana(max_events=args.max_events, threshold_SOL=args.threshold_sol)
+    )
+    print("FINAL RESULTS:")
+    for r in results:
+        print(r)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- convert watcher.py script into package module
- expose `monitor_solana` via `app.watcher`
- add CLI runner via `python -m app.watcher`
- document module usage in README

## Testing
- `pytest -q`
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68869d953bac8323b597dedc0df5768b